### PR TITLE
Fix: Handle undefined ID in insertConsentState to prevent Sandboxed JS TypeError

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -411,7 +411,7 @@ const isDefined = (s) => {
 const convertBooleanToGrantedOrDenied = (boolean) => boolean ? ConsentType.GRANTED : ConsentType.DENIED;
 
 const insertConsentState = (id, consentStates, consentTypeName, isDefault, defaultGranted, prefCookie) => {
-  if (id === "" || id <= -1) {
+  if (id === undefined || id === "" || id <= -1) {
     Log("No Category Mapping found for " + consentTypeName +". Skipping.");
     return;
   }


### PR DESCRIPTION
Description:
Currently, when a user leaves a consent category mapping empty in the GTM Template UI (e.g., they don't map ad_user_data), the id variable is passed into the insertConsentState function as undefined.

The previous logic if (id === "" || id <= -1) fails to return early because undefined <= -1 evaluates to false in JavaScript.

Because the execution doesn't abort early, the script later attempts to execute prefCookie.indexOf(id), which resolves to prefCookie.indexOf(undefined). While standard JS handles this by coercing to a string, GTM's strict Sandboxed JavaScript environment throws a TypeError.

This silent error crashes the addConsentListenerTA callback, completely breaking the dynamic update functionality of Google Consent Mode when a user updates their preferences on the page.

Changes:
Updated the early return condition to explicitly check for undefined:
if (id === undefined || id === "" || id <= -1)

This safely catches empty mappings, logs the "Skipping" message, and allows the dynamic listener to execute successfully for the mapped categories.