### PR TITLE
Enable dynamic Google Consent Mode updates without page refresh by removing gtag mapping bypass

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -561,10 +561,10 @@ if (data.integrateGCM) {
 
   callInWindow('addConsentListenerTA', function (prefCookie, behaviorCookie) {
     Log("Callback executed!!");
-    if (hasGtagMapping()) {
-      Log ("gtag mapping found. Skipping template consent update.");
-      return;
-    }
+    // if (hasGtagMapping()) {
+    //  Log ("gtag mapping found. Skipping template consent update.");
+    //  return;
+    // }
     if (!hasDefaultConsent) {
       defaultConsent(behaviorCookie);
     } else if (isDefined(prefCookie)) {


### PR DESCRIPTION
Description:
Currently, when a user updates their preferences in the TrustArc banner without refreshing the page, the new consent state is not reflected within Google Tag Manager.

This occurs because the addConsentListenerTA callback includes a hasGtagMapping() check. If the template detects that Consent Mode is mapped in the TrustArc backend Admin UI, it assumes the backend script will handle the update and explicitly aborts the callback using a return; statement. Because it aborts early, GTM's native updateConsentState() API is never triggered dynamically. Consequently, tags relying on GTM's consent state remain dormant or use the old state until the next full page load, causing a loss of data on the landing page.

Changes:
Commented out the hasGtagMapping() check block inside the addConsentListenerTA callback. This ensures that whenever a user saves their preferences, the GTM template will always successfully execute updateConsentState(). This keeps GTM's internal consent state perfectly synchronized with TrustArc in real-time, completely eliminating the need for a page refresh.